### PR TITLE
force installation of uyuni version of httpcomponents-asyncclient

### DIFF
--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -46,6 +46,7 @@ if [[ $ret -ne 0 ]];then
     echo "Migration went wrong. Please fix the issues and try again. return code is $ret"
     exit -1
 fi
+zypper in --force --from "Uyuni Server Stable" httpcomponents-asyncclient
 
 CURRENT_VERSION_ID=$(cat /etc/os-release  | grep VERSION_ID | cut -f2 -d=)
 


### PR DESCRIPTION
## What does this PR change?

Take care that the uyuni version of httpcomponents-asyncclient package gets installed.
This is the only one which works.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/17609

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
